### PR TITLE
DHWP-909. Add audit event data.

### DIFF
--- a/examples/js/webhook.test.js
+++ b/examples/js/webhook.test.js
@@ -55,7 +55,7 @@ test('Authorize Webhook', async () => {
 
   let token = await shared.getAccessToken(['dockhealth/system.developer.write'])
   let headers = shared.devHeaders(token)
-  let events = ['ORGANIZATION_CREATED']
+  let events = ['CREATE_ORGANIZATION']
 
   // Setup ngrok to proxy to our local server on port 3000.
   const ngrokOptions = {
@@ -97,7 +97,7 @@ test('Authorize Webhook', async () => {
 
   token = await shared.getAccessToken(['dockhealth/system.developer.write'])
   headers = shared.devHeaders(token)
-  events = ['ORGANIZATION_CREATED', 'ORGANIZATION_UPDATED']
+  events = ['CREATE_ORGANIZATION', 'UPDATE_ORGANIZATION']
 
   await request
     .put('/api/v1/developer/webhook/' + id)


### PR DESCRIPTION
DHWP-909. Add audit event data.
Refactor to base events on audit types and audit service calls.
Javers diffs are attached on demand.
Use Instants for Dynamo timestamps instead of LocalDateTime to remove timezone ambiguity.
Update docs and tests and add full list of event types to WEBHOOKS.md.